### PR TITLE
minicoro: add pure V C-style call API, small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,4 @@ fn main () {
 - [ ] WebAssembly support
 - [ ] Raspberry Pi support
 - [ ] RISC-V support
+- [ ] Add CI tests

--- a/minicoro.c.v
+++ b/minicoro.c.v
@@ -32,13 +32,13 @@ $if debug {
 #include "minicoro.h"
 
 [callconv: 'fastcall']
-type FuncCoro = fn (co &Coro)
+pub type FuncCoro = fn (co &Coro)
 
 [callconv: 'fastcall']
-type FreeCB = fn (ptr voidptr, allocator_data voidptr)
+pub type FreeCB = fn (ptr voidptr, allocator_data voidptr)
 
 [callconv: 'fastcall']
-type MallocCB = fn (size usize, allocator_data voidptr) voidptr // [void* (*malloc_cb)(size_t size, void* allocator_data);]
+pub type MallocCB = fn (size usize, allocator_data voidptr) voidptr // [void* (*malloc_cb)(size_t size, void* allocator_data);]
 
 // CONSTANTS //
 pub const (
@@ -77,7 +77,7 @@ pub enum Result {
 }
 
 [typedef]
-pub struct C.mco_coro {
+struct C.mco_coro {
 pub mut:
 	context         voidptr
 	state           State
@@ -101,7 +101,7 @@ pub mut:
 pub type Coro = C.mco_coro
 
 [typedef]
-pub struct C.mco_desc {
+struct C.mco_desc {
 pub mut:
 	func      FuncCoro // Entry point function for the coroutine. [void (*func)(mco_coro* co);]
 	user_data voidptr  // Coroutine user data, can be get with `mco_get_user_data`.

--- a/minicoro.c.v
+++ b/minicoro.c.v
@@ -42,19 +42,25 @@ type MallocCB = fn (size usize, allocator_data voidptr) voidptr // [void* (*mall
 
 // CONSTANTS //
 pub const (
-	minicoro_v_version = '0.0.2'
+	minicoro_v_version = '0.0.3'
 	minicoro_c_version = '0.1.3'
 )
 
-// STRUCTS //
-pub enum State { // Coroutine states
+pub const (
+	default_stack_size = C.MCO_DEFAULT_STACK_SIZE
+	min_stack_size     = C.MCO_MIN_STACK_SIZE
+)
+
+// State represents all coroutine states.
+pub enum State {
 	dead = 0 // The coroutine has finished normally or was uninitialized before finishing.
 	normal // The coroutine is active but not running (that is, it has resumed another coroutine).
 	running // The coroutine is active and running.
 	suspended // The coroutine is suspended (in a call to yield, or it has not started running yet).
 }
 
-pub enum Result { // Coroutine result codes.
+// Result holds coroutine result codes.
+pub enum Result {
 	success = 0
 	generic_error
 	invalid_pointer
@@ -72,7 +78,7 @@ pub enum Result { // Coroutine result codes.
 
 [typedef]
 pub struct C.mco_coro {
-pub mut: 
+pub mut:
 	context         voidptr
 	state           State
 	func            FuncCoro // [void (*func)(mco_coro* co);]
@@ -91,46 +97,144 @@ pub mut:
 	magic_number    usize   // Used to check stack overflow.
 }
 
-// Coroutine structure.
+// Coro is the coroutine structure.
 pub type Coro = C.mco_coro
 
 [typedef]
 pub struct C.mco_desc {
-pub mut: 
-	func           FuncCoro // Entry point function for the coroutine. [void (*func)(mco_coro* co);]
-	user_data      voidptr  // Coroutine user data, can be get with `mco_get_user_data`.
+pub mut:
+	func      FuncCoro // Entry point function for the coroutine. [void (*func)(mco_coro* co);]
+	user_data voidptr  // Coroutine user data, can be get with `mco_get_user_data`.
 	// Custom allocation interface.
 	malloc_cb      MallocCB // Custom allocation function.   [void* (*malloc_cb)(size_t size, void* allocator_data);]
 	free_cb        FreeCB   // Custom deallocation function. [void  (*free_cb)(void* ptr, void* allocator_data);]
 	allocator_data voidptr  // User data pointer passed to `malloc`/`free` allocation functions.
 	storage_size   usize    // Coroutine storage size, to be used with the storage APIs.
 	// These must be initialized only through `mco_init_desc`.
-	coro_size      usize    // Coroutine structure size.
-	stack_size     usize    // Coroutine stack size.
+	coro_size  usize // Coroutine structure size.
+	stack_size usize // Coroutine stack size.
 }
 
-// Structure used to initialize a coroutine.
+// Desc is a structure used to initialize a coroutine.
 pub type Desc = C.mco_desc
 
 // FUNCTIONS //
 // Coroutine functions.
-fn C.mco_desc_init(co FuncCoro, stack_size usize) Desc // Initialize description of a coroutine. When stack size is 0 then MCO_DEFAULT_STACK_SIZE is used.
-fn C.mco_init(co &Coro, desc &Desc) Result // Initialize the coroutine.
-fn C.mco_uninit(co &Coro) Result // Uninitialize the coroutine, may fail if it's not dead or suspended.
-fn C.mco_create(out_co &&Coro, desc &Desc) Result // Allocates and initializes a new coroutine.
-fn C.mco_destroy(co &Coro) Result // Uninitialize and deallocate the coroutine, may fail if it's not dead or suspended.
-fn C.mco_resume(co &Coro) Result // Starts or continues the execution of the coroutine.
-fn C.mco_yield(co &Coro) Result // Suspends the execution of a coroutine.
-fn C.mco_status(co &Coro) State // Returns the status of the coroutine.
-fn C.mco_get_user_data(co &Coro) voidptr // Get coroutine user data supplied on coroutine creation.
+fn C.mco_desc_init(co FuncCoro, stack_size usize) Desc
+
+// desc_init initializes a description of a coroutine.
+// When `stack_size` is 0 then `default_stack_size` is used.
+pub fn desc_init(co FuncCoro, stack_size usize) Desc {
+	return C.mco_desc_init(co, stack_size)
+}
+
+fn C.mco_init(co &Coro, desc &Desc) Result
+
+// init initializes the coroutine.
+pub fn init(co &Coro, desc &Desc) Result {
+	return C.mco_init(co, desc)
+}
+
+fn C.mco_uninit(co &Coro) Result
+
+// uninit uninitializes the coroutine `co`,
+// may fail if it's not dead or suspended.
+pub fn uninit(co &Coro) Result {
+	return C.mco_uninit(co)
+}
+
+fn C.mco_create(out_co &&Coro, desc &Desc) Result
+
+// create allocates and initializes a new coroutine.
+pub fn create(out_co &&Coro, desc &Desc) Result {
+	return C.mco_create(out_co, desc)
+}
+
+fn C.mco_destroy(co &Coro) Result
+
+// destroy uninitializes and deallocates the coroutine,
+// the function may fail if it's not dead or suspended.
+pub fn destroy(co &Coro) Result {
+	return C.mco_destroy(co)
+}
+
+fn C.mco_resume(co &Coro) Result
+
+// resume starts or continues the execution of the coroutine.
+pub fn resume(co &Coro) Result {
+	return C.mco_resume(co)
+}
+
+fn C.mco_yield(co &Coro) Result
+
+// yield suspends (yields) the execution of a coroutine.
+pub fn yield(co &Coro) Result {
+	return C.mco_yield(co)
+}
+
+fn C.mco_status(co &Coro) State
+
+// status returns the status of the coroutine.
+pub fn status(co &Coro) State {
+	return C.mco_status(co)
+}
+
+fn C.mco_get_user_data(co &Coro) voidptr
+
+// get_user_data gets coroutine user data supplied on coroutine creation.
+pub fn get_user_data(co &Coro) voidptr {
+	return C.mco_get_user_data(co)
+}
 
 // Storage interface functions, used to pass values between yield and resume.
-fn C.mco_push(co &Coro, src voidptr, len usize) Result // Push bytes to the coroutine storage. Use to send values between yield and resume.
-fn C.mco_pop(co &Coro, dest voidptr, len usize) Result // Pop bytes from the coroutine storage. Use to get values between yield and resume.
-fn C.mco_peak(co &Coro, dest voidptr, len usize) Result // Like `mco_pop` but it does not consumes the storage.
-fn C.mco_get_bytes_stored(co &Coro) usize // Get the available bytes that can be retrieved with a `mco_pop`.
-fn C.mco_get_storage_size(co &Coro) usize // Get the total storage size.
+fn C.mco_push(co &Coro, src voidptr, len usize) Result
+
+// push pushes bytes to the coroutine storage.
+// Use to send values between yield and resume.
+pub fn push(co &Coro, src voidptr, len usize) Result {
+	return C.mco_push(co, src, len)
+}
+
+fn C.mco_pop(co &Coro, dest voidptr, len usize) Result
+
+// pop pops bytes from the coroutine storage.
+// Use to get values between yield and resume.
+pub fn pop(co &Coro, dest voidptr, len usize) Result {
+	return C.mco_pop(co, dest, len)
+}
+
+fn C.mco_peek(co &Coro, dest voidptr, len usize) Result
+
+// peek works like `pop` but it does not consume the storage.
+pub fn peek(co &Coro, dest voidptr, len usize) Result {
+	return C.mco_peek(co, dest, len)
+}
+
+fn C.mco_get_bytes_stored(co &Coro) usize
+
+// get_bytes_stored gets the available bytes that can be retrieved with a `pop`.
+pub fn get_bytes_stored(co &Coro) usize {
+	return C.mco_get_bytes_stored(co)
+}
+
+fn C.mco_get_storage_size(co &Coro) usize
+
+// get_storage_size gets the total storage size.
+pub fn get_storage_size(co &Coro) usize {
+	return C.mco_get_storage_size(co)
+}
 
 // Misc functions.
-fn C.mco_coro() voidptr // Returns the running coroutine for the current thread.
-fn C.mco_result_description(res Result) byteptr // Get the description of a result.
+fn C.mco_running() &Coro
+
+// running returns the running coroutine for the current thread.
+pub fn running() &Coro {
+	return C.mco_running()
+}
+
+fn C.mco_result_description(res Result) &char
+
+// result_description gets the description of a result.
+pub fn result_description(res Result) &char {
+	return C.mco_result_description(res)
+}

--- a/minicoro_test.v
+++ b/minicoro_test.v
@@ -15,32 +15,32 @@ fn test_simple() {
 
 	// Configure `desc` fields when needed (e.g. customize user_data or allocation functions).
 	desc.user_data = voidptr(0)
-	mut co := &Mco_Coro{}
+	mut co := &Coro{}
 
 	// Call `mco_create` with the output coroutine pointer and `desc` pointer.
 	mut res := C.mco_create(&co, &desc)
-	assert res == Mco_Result.mco_success
+	assert res == .success
 	// println(res)
 
 	// The coroutine should be now in suspended state.
-	assert C.mco_status(co) == Mco_State.mco_suspended
+	assert C.mco_status(co) == .suspended
 
 	// Call `mco_resume` to start for the first time, switching to its context.
 	res = C.mco_resume(co) // Should print "coroutine 1".
-	assert res == Mco_Result.mco_success
+	assert res == .success
 
 	// We get back from coroutine context in suspended state
 	// because the coro_entry method yields after the first print
-	assert C.mco_status(co) == Mco_State.mco_suspended
+	assert C.mco_status(co) == .suspended
 
 	// Call `mco_resume` to resume for a second time.
 	res = C.mco_resume(co) // Should print "coroutine 2".
-	assert res == Mco_Result.mco_success
+	assert res == .success
 
 	// The coroutine finished and should be now dead.
-	assert C.mco_status(co) == Mco_State.mco_dead
+	assert C.mco_status(co) == .dead
 
 	// Call `mco_destroy` to destroy the coroutine.
 	res = C.mco_destroy(co)
-	assert res == Mco_Result.mco_success
+	assert res == .success
 }

--- a/minicoro_v_api_test.v
+++ b/minicoro_v_api_test.v
@@ -1,51 +1,44 @@
-module main
-
-import lazalong.minicoro
+module minicoro
 
 [callconv: 'fastcall']
-pub fn coro_entry(co &minicoro.Coro) {
-	println('  Coroutine 1 - magic nb: $co.magic_number')
-	res := minicoro.yield(co)
-	str_res := unsafe { cstring_to_vstring(minicoro.result_description(res)) }
-	println('  Coroutine 2 - magic nb: $co.magic_number "$str_res"')
+pub fn coro_entry(co &Coro) {
+	yield(co)
 }
 
 [console]
-fn main() {
-	println('Simple Minicoro Example')
-
+fn test_simple() {
 	// First initialize a `desc` object through `mco_desc_init`.
 	fct := voidptr(&coro_entry)
-	mut desc := minicoro.desc_init(fct, 0)
+	mut desc := desc_init(fct, 0)
 
 	// Configure `desc` fields when needed (e.g. customize user_data or allocation functions).
 	desc.user_data = voidptr(0)
-	mut co := &minicoro.Coro{}
+	mut co := &Coro{}
 
 	// Call `mco_create` with the output coroutine pointer and `desc` pointer.
-	mut res := minicoro.create(&co, &desc)
+	mut res := create(&co, &desc)
 	assert res == .success
 	// println(res)
 
 	// The coroutine should be now in suspended state.
-	assert minicoro.status(co) == .suspended
+	assert status(co) == .suspended
 
 	// Call `mco_resume` to start for the first time, switching to its context.
-	res = minicoro.resume(co) // Should print "coroutine 1".
+	res = resume(co) // Should print "coroutine 1".
 	assert res == .success
 
 	// We get back from coroutine context in suspended state
 	// because the coro_entry method yields after the first print
-	assert minicoro.status(co) == .suspended
+	assert status(co) == .suspended
 
 	// Call `mco_resume` to resume for a second time.
-	res = minicoro.resume(co) // Should print "coroutine 2".
+	res = resume(co) // Should print "coroutine 2".
 	assert res == .success
 
 	// The coroutine finished and should be now dead.
-	assert minicoro.status(co) == .dead
+	assert status(co) == .dead
 
 	// Call `mco_destroy` to destroy the coroutine.
-	res = minicoro.destroy(co)
+	res = destroy(co)
 	assert res == .success
 }

--- a/v.mod
+++ b/v.mod
@@ -2,7 +2,7 @@ Module {
 	name: 'minicoro'
 	description: 'A minicoro wrapper written in V'
 	author: 'lazalong'
-	version: '0.0.2'
+	version: '0.0.3'
 	license: 'MIT'
 	dependencies: []
 }


### PR DESCRIPTION
This PR will expose the complete API via public V function wrappers of all available C functions:
**E.g.:** `C.mco_resume(co)` -> `minicoro.resume(co)`.

For this specific C library, since it's small and straight forward (so far), it could make good sense to wrap some of the C API as **methods** on the `Coro` struct, though (or both?)... Let me hear what you think - it's an easy change:
**E.g.:** `C.mco_resume(co)` / `minicoro.resume(co)` -> `co.resume()`.

On top, this PR also fixes
* `mco_peak` (renamed to `mco_peek`)
* `mco_coro` -> renamed to `mco_running`/`minicoro.running` (`mco_coro` was the return type :slightly_smiling_face:)
* Failing tests after the `Mco_Result` -> `Result` change

I've added a test for the V API `minicoro_v_api_test.v`

... As added bonuses, the whole project can now be formatted easily by running `v fmt -w .` in the project root and you can generate/read documentation with `vdoc` :slightly_smiling_face:

Example:
```
cd $HOME/.vmodules/lazalong/minicoro
v doc -f html .
firefox ./lazalong.minicoro.html
# !! Note that this will generate a lot of HTML/CSS files in the project root !!
# (They can be cleaned up with git clean)
```
![image](https://user-images.githubusercontent.com/768942/167384300-2edbb070-d963-493d-922b-d8f25fbabe79.png)



I also think the project could benefit from CI so things doesn't break going forward - let me know what you think and we can start setting it up if you think it's a good idea.